### PR TITLE
fix(config): set correct key on service provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@ A Laravel package that allows you to assign settings to your models.
 [![GitHub license](https://img.shields.io/github/license/CodeTechPt/laravel-model-settings?style=flat-square)](https://github.com/CodeTechPt/laravel-model-settings/blob/master/LICENSE)
 
 
-## Installation
+## Installation & setup
 
 Add the package to your Laravel app using composer
 
 ```
 composer require codetech/laravel-model-settings
+```
+
+For changing migrations and configurations, you will need to publish both files by running the following Artisan command:
+
+```
+php artisan vendor:publish --provider="CodeTech\ModelSettings\Providers\ModelSettingsServiceProvider"
 ```
 
 

--- a/src/Providers/ModelSettingsServiceProvider.php
+++ b/src/Providers/ModelSettingsServiceProvider.php
@@ -16,7 +16,7 @@ class ModelSettingsServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/model-settings.php', 'settingable'
+            __DIR__ . '/../config/model-settings.php', 'model-settings'
         );
     }
 


### PR DESCRIPTION
### Description

 - The configuration key name on the Service Provider has been fixed.  
 - Instructions were added to the README file about publishing the package's migrations and configuration files.

### Fixes

This has no ticket.
